### PR TITLE
"out of range" fixed generate.py

### DIFF
--- a/src/generate.py
+++ b/src/generate.py
@@ -81,7 +81,7 @@ def generate_images(
                     path
                     for path in files_path
                     if attr["trait_type"] in path.split("/")[1]
-                    and attr["value"][2] in path.split("/")[2]
+                    and attr["value"] in path.split("/")[2]
                 )
                 for attr in attributes
             ]


### PR DESCRIPTION
## Fixed "Index out of range"

Error while executing generate.py. There's no [2] in attr["value"].

```
File "~/generate-nft-images/src/generate.py", line 84, in <genexpr>
    and attr["value"][2] in path.split("/")[2]
IndexError: string index out of range
```
